### PR TITLE
feat: respect balance config in admin backend

### DIFF
--- a/admin-backend/index.js
+++ b/admin-backend/index.js
@@ -1,6 +1,17 @@
 const express = require('express');
 const mongoose = require('mongoose');
 const cors = require('cors');
+const path = require('path');
+const { getBalanceConfig } = require('../api/server/services/Config/getCustomConfig');
+
+let createTransaction;
+try {
+  require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
+  ({ createTransaction } = require('../api/models/Transaction'));
+} catch (e) {
+  console.warn('createTransaction not available:', e.message);
+}
+
 const {
   User,
   Balance,
@@ -19,24 +30,20 @@ mongoose.connect(MONGO_URI)
   .catch(err => console.error('Admin Backend MongoDB connection error:', err));
 
 // Helper function to get all balances
-async function getAllBalances() {
+async function getAllBalances(startBalance = 0) {
   const users = await User.find({});
   const balances = [];
   for (const user of users) {
-    const balance = await Balance.findOne({ user: user._id });
-    if (balance) {
-      balances.push({
-        id: user._id,
-        email: user.email,
-        balance: balance.tokenCredits,
-      });
-    } else {
-      balances.push({
-        id: user._id,
-        email: user.email,
-        balance: 0, // Default to 0 if no balance found
-      });
+    let balance = await Balance.findOne({ user: user._id });
+    if (!balance) {
+      balance = new Balance({ user: user._id, tokenCredits: startBalance });
+      await balance.save();
     }
+    balances.push({
+      id: user._id,
+      email: user.email,
+      balance: balance.tokenCredits,
+    });
   }
   return balances;
 }
@@ -93,7 +100,11 @@ const Invite = mongoose.models.Invite || mongoose.model('Invite', InviteSchema);
 // API endpoint for balances
 app.get('/api/balances', async (req, res) => {
   try {
-    const balances = await getAllBalances();
+    const balanceConfig = await getBalanceConfig();
+    if (!balanceConfig?.enabled) {
+      return res.status(403).json({ message: 'Balance feature disabled' });
+    }
+    const balances = await getAllBalances(balanceConfig.startBalance ?? 0);
     res.json(balances);
   } catch (error) {
     console.error('Error fetching balances:', error);
@@ -124,16 +135,38 @@ app.get('/api/translations', async (req, res) => {
 });
 app.put('/api/balances/:id', async (req, res) => {
   try {
+    const balanceConfig = await getBalanceConfig();
+    if (!balanceConfig?.enabled) {
+      return res.status(403).json({ message: 'Balance feature disabled' });
+    }
     const { id } = req.params;
-    const { tokenCredits } = req.body;
-    if (typeof tokenCredits !== 'number') {
+    const tokenCredits = Number(req.body.tokenCredits);
+    if (!Number.isFinite(tokenCredits)) {
       return res.status(400).json({ message: 'tokenCredits must be a number' });
     }
-    const updatedBalance = await Balance.findOneAndUpdate(
-      { user: id },
-      { tokenCredits },
-      { upsert: true, new: true }
-    );
+    let updatedBalance;
+    if (createTransaction) {
+      let existingBalance = await Balance.findOne({ user: id });
+      if (!existingBalance && balanceConfig.startBalance != null) {
+        existingBalance = new Balance({ user: id, tokenCredits: balanceConfig.startBalance });
+        await existingBalance.save();
+      }
+      const currentCredits = existingBalance ? existingBalance.tokenCredits : 0;
+      const delta = tokenCredits - currentCredits;
+      await createTransaction({
+        user: id,
+        tokenType: 'credits',
+        context: 'admin',
+        rawAmount: delta,
+      });
+      updatedBalance = await Balance.findOne({ user: id });
+    } else {
+      updatedBalance = await Balance.findOneAndUpdate(
+        { user: id },
+        { tokenCredits },
+        { upsert: true, new: true },
+      );
+    }
     res.json(updatedBalance);
   } catch (error) {
     console.error('Error updating balance:', error);


### PR DESCRIPTION
## Summary
- add balance config import and optional transaction logging
- honor balanceConfig.enabled and startBalance in balance handlers
- initialize missing balances and support transaction-based updates
- parse tokenCredits input before validation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run test:api` (fails: MongoDB download error)


------
https://chatgpt.com/codex/tasks/task_e_68960d77afa4832c8518a567e5e35310