### PR TITLE
fix: remove duplicate path import causing server crash

### DIFF
--- a/admin-backend/index.js
+++ b/admin-backend/index.js
@@ -3,7 +3,6 @@ const express = require('express');
 const mongoose = require(path.resolve(__dirname, '..', 'api', 'node_modules', 'mongoose'));
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
 const cors = require('cors');
-const path = require('path');
 const { getBalanceConfig } = require('../api/server/services/Config/getCustomConfig');
 
 let createTransaction;


### PR DESCRIPTION
## Summary
- remove duplicate `path` import in `admin-backend/index.js`

## Testing
- `npm run test:api` *(fails: Cannot find module 'librechat-data-provider')*
- `npx eslint admin-backend/index.js` *(fails: 12 problems (10 errors, 2 warnings))*


------
https://chatgpt.com/codex/tasks/task_e_6896148802f4832cb9316ec5a89eeadb